### PR TITLE
Feature updates & changes

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -1,0 +1,23 @@
+name: 'Terraform'
+
+on:
+  pull_request:
+
+jobs:
+  terraform:
+    name: 'Terraform'
+    runs-on: ubuntu-20.04
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v1
+
+    - name: Terraform Format
+      run: terraform fmt -check

--- a/acme_volume.tf
+++ b/acme_volume.tf
@@ -1,4 +1,4 @@
 # Create docker volume for acme.json storage
 resource "docker_volume" "traefik_acme" {
-  name   = "traefik_acme"
+  name = "traefik_acme"
 }

--- a/cert_resolvers/dnsChallenge/cloudflare.yaml
+++ b/cert_resolvers/dnsChallenge/cloudflare.yaml
@@ -1,0 +1,24 @@
+    cloudflare:
+        acme:
+            email: "${acme_email}"
+            caServer: ${le_production_url}
+            storage: ${acme_storage_path}
+            keyType: "${lets_encrypt_keytype}"
+            dnsChallenge:
+              provider: cloudflare
+              delayBeforeCheck: 0
+              resolvers:
+                  - "${cf_dns_resolver_a}:53"
+                  - "${google_dns_resolver_a}:53"
+    cloudflareStaging:
+        acme:
+            email: "${acme_email}"
+            caServer: ${le_staging_url}
+            storage: ${acme_storage_path}
+            keyType: "${lets_encrypt_keytype}"
+            dnsChallenge:
+              provider: cloudflare
+              delayBeforeCheck: 0
+              resolvers:
+                  - "${cf_dns_resolver_a}:53"
+                  - "${google_dns_resolver_a}:53"

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,20 @@
+locals {
+
+  LE_PRODUCTION_URL = "https://acme-v02.api.letsencrypt.org/directory"
+  LE_STAGING_URL    = "https://acme-staging-v02.api.letsencrypt.org/directory"
+
+  ACME_STORAGE_PATH = "/etc/traefik/acme/acme.json"
+
+  CF_DNS_RESOLVER_A = "1.1.1.1"
+  CF_DNS_RESOLVER_B = "1.0.0.1"
+
+  GOOGLE_DNS_RESOLVER_A = "8.8.8.8"
+  GOOGLE_DNS_RESOLVER_B = "8.8.4.4"
+
+  QUAD9_DNS_RESOLVER_A = "9.9.9.9"
+  QUAD9_DNS_RESOLVER_B = "149.112.112.112"
+
+  LEVEL3_DNS_RESOLVER_A = "209.244.0.3"
+  LEVEL3_DNS_RESOLVER_B = "209.244.0.4"
+
+}

--- a/service.tf
+++ b/service.tf
@@ -10,6 +10,8 @@ resource "docker_service" "traefik" {
         # Cloudflare API Tokens for Let's Encrypt DNS Challange
         CF_DNS_API_TOKEN  = var.cloudflare_dns_token
         CF_ZONE_API_TOKEN = var.cloudflare_zone_token
+        CF_API_EMAIL      = var.cloudflare_email
+        CF_API_KEY        = var.cloudflare_api_key
       }
 
       labels {
@@ -54,7 +56,7 @@ resource "docker_service" "traefik" {
 
       labels {
         label = "traefik.http.routers.traefik.tls.certresolver"
-        value = "letsEncrypt"
+        value = var.traefik_ssl_cert == "staging" ? "letsEncryptStaging" : "letsEncrypt"
       }
 
       labels {

--- a/service_conf.tf
+++ b/service_conf.tf
@@ -5,9 +5,9 @@ resource "docker_config" "traefik-yaml" {
     traefik_network      = var.traefik_network
     acme_email           = var.acme_email
     lets_encrypt_keytype = var.lets_encrypt_keytype
-    le_production_url     = local.LE_PRODUCTION_URL
-    le_staging_url        = local.LE_STAGING_URL
-    acme_storage_path     = local.ACME_STORAGE_PATH
+    le_production_url    = local.LE_PRODUCTION_URL
+    le_staging_url       = local.LE_STAGING_URL
+    acme_storage_path    = local.ACME_STORAGE_PATH
   }))
 
   lifecycle {

--- a/service_conf.tf
+++ b/service_conf.tf
@@ -1,6 +1,14 @@
 resource "docker_config" "traefik-yaml" {
   name = "traefik-yaml-${replace(timestamp(), ":", ".")}"
-  data = base64encode(data.template_file.traefik-yaml.rendered)
+  data = base64encode(templatefile("${path.module}/traefik.yaml", {
+    cf_resolver          = contains(var.lets_encrypt_resolvers, "cloudflare") ? data.template_file.cloudflare-yaml.rendered : ""
+    traefik_network      = var.traefik_network
+    acme_email           = var.acme_email
+    lets_encrypt_keytype = var.lets_encrypt_keytype
+    le_production_url     = local.LE_PRODUCTION_URL
+    le_staging_url        = local.LE_STAGING_URL
+    acme_storage_path     = local.ACME_STORAGE_PATH
+  }))
 
   lifecycle {
     ignore_changes        = [name]

--- a/traefik.yaml
+++ b/traefik.yaml
@@ -22,26 +22,24 @@ api:
 # Let's Encrypt
 certificatesResolvers:
     letsEncrypt:
-      acme:
-          email: "${acme_email}"
-          caServer: "${lets_encrypt_env}" # Use Let's Encrypt staging server (default) when experimenting to avoid hitting Let's Encrypts rate limit
-          storage: /etc/traefik/acme/acme.json
-          keyType: "${lets_encrypt_keytype}"
-          httpChallenge:
-              # used during the challenge
-              entryPoint: http
-    cloudflare:
-      acme:
-        email: "${acme_email}"
-        caServer: "${lets_encrypt_env}" # Use Let's Encrypt staging server (default) when experimenting to avoid hitting Let's Encrypts rate limit
-        storage: /etc/traefik/acme/acme.json
-        keyType: "${lets_encrypt_keytype}"
-        dnsChallenge:
-          provider: cloudflare
-          delayBeforeCheck: 0
-          resolvers:
-            - "1.1.1.1:53"
-            - "8.8.8.8:53"
+        acme:
+            email: "${acme_email}"
+            caServer: ${le_production_url} # Use Let's Encrypt staging server when experimenting to avoid hitting Let's Encrypts rate limit
+            storage: ${acme_storage_path}
+            keyType: "${lets_encrypt_keytype}"
+            httpChallenge:
+                # used during the challenge
+                entryPoint: http
+    letsEncryptStaging:
+        acme:
+            email: "${acme_email}"
+            caServer: ${le_staging_url}
+            storage: ${acme_storage_path}
+            keyType: "${lets_encrypt_keytype}"
+            httpChallenge:
+                # used during the challenge
+                entryPoint: http
+${cf_resolver}
 
 accessLog: {}
 

--- a/traefik_tpl.tf
+++ b/traefik_tpl.tf
@@ -13,17 +13,3 @@ data "template_file" "cloudflare-yaml" {
     //google_dns_resolver_b = local.GOOGLE_DNS_RESOLVER_B
   }
 }
-
-# data "local_file" "traefik-yaml" {
-#   filename = "${path.module}/traefik.yaml"
-# }
-# data "template_file" "traefik-yaml" {
-#   template = "${file("${path.module}/traefik.yaml")}"
-
-#   vars = {
-#     traefik_network      = var.traefik_network
-#     acme_email           = var.acme_email
-#     lets_encrypt_keytype = var.lets_encrypt_keytype
-#     lets_encrypt_env     = var.lets_encrypt_env == "staging" ? "https://acme-staging-v02.api.letsencrypt.org/directory" : "https://acme-v02.api.letsencrypt.org/directory"
-#   }
-# }

--- a/traefik_tpl.tf
+++ b/traefik_tpl.tf
@@ -1,13 +1,29 @@
-data "local_file" "traefik-yaml" {
-  filename = "${path.module}/traefik.yaml"
-}
-data "template_file" "traefik-yaml" {
-  template = file("${path.module}/traefik.yaml")
+data "template_file" "cloudflare-yaml" {
+  template = file("${path.module}/cert_resolvers/dnsChallenge/cloudflare.yaml")
 
   vars = {
-    traefik_network      = var.traefik_network
-    acme_email           = var.acme_email
-    lets_encrypt_keytype = var.lets_encrypt_keytype
-    lets_encrypt_env     = var.lets_encrypt_env == "staging" ? "https://acme-staging-v02.api.letsencrypt.org/directory" : "https://acme-v02.api.letsencrypt.org/directory"
+    acme_email            = var.acme_email
+    lets_encrypt_keytype  = var.lets_encrypt_keytype
+    le_production_url     = local.LE_PRODUCTION_URL
+    le_staging_url        = local.LE_STAGING_URL
+    acme_storage_path     = local.ACME_STORAGE_PATH
+    cf_dns_resolver_a     = local.CF_DNS_RESOLVER_A
+    google_dns_resolver_a = local.GOOGLE_DNS_RESOLVER_A
+    //cf_dns_resolver_b    = local.CF_DNS_RESOLVER_B
+    //google_dns_resolver_b = local.GOOGLE_DNS_RESOLVER_B
   }
 }
+
+# data "local_file" "traefik-yaml" {
+#   filename = "${path.module}/traefik.yaml"
+# }
+# data "template_file" "traefik-yaml" {
+#   template = "${file("${path.module}/traefik.yaml")}"
+
+#   vars = {
+#     traefik_network      = var.traefik_network
+#     acme_email           = var.acme_email
+#     lets_encrypt_keytype = var.lets_encrypt_keytype
+#     lets_encrypt_env     = var.lets_encrypt_env == "staging" ? "https://acme-staging-v02.api.letsencrypt.org/directory" : "https://acme-v02.api.letsencrypt.org/directory"
+#   }
+# }

--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,7 @@ variable "traefik_network_attachable" {
 variable "traefik_version" {
   type        = string
   description = "Traefik Docker image version."
-  default     = "2.3.5" # https://github.com/traefik/traefik/releases/latest
+  default     = "2.3.4" # https://github.com/traefik/traefik/releases/latest
 }
 
 variable "password" {
@@ -40,12 +40,12 @@ variable "password" {
   default     = "traefik"
 }
 
-variable "lets_encrypt_env" {
+variable "traefik_ssl_cert" {
   type        = string
-  description = "The Let's Encrypt environment to use when requesting the SSL certificate for Traefik: staging, production"
+  description = "The Let's Encrypt environment to use when requesting the SSL certificate for the Traefik instance: staging, production"
   default     = "staging" # Prevents hitting Let's Encrypts rate limit when testing.
   validation {
-    condition     = length(regexall("^staging|production$", var.lets_encrypt_env)) > 0
+    condition     = length(regexall("^staging|production$", var.traefik_ssl_cert)) > 0
     error_message = "Let's Encrypt enviroment variable should be staging or production."
   }
 }
@@ -59,6 +59,18 @@ variable "lets_encrypt_keytype" {
     error_message = "Invalid key type value. Valid Let's Encrypt key types are EC256, EC384, RSA2048, RSA4096, RSA8192."
   }
 }
+
+variable "lets_encrypt_resolvers" {
+  type = list(string)
+  description = "A list of DNS Challange providers to enable in the Traefik configuration"
+  default = []
+  validation {
+    condition    = can([for provider in var.lets_encrypt_resolvers : regex("^cloudflare$", provider)])
+    error_message = "Invalid/Unsupported DNS Provider listed. Supported values are: cloudflare."
+  }
+}
+
+# Cloudflare DNS Variables
 
 variable "cloudflare_dns_token" {
   type        = string
@@ -75,5 +87,11 @@ variable "cloudflare_zone_token" {
 variable "cloudflare_email" {
   type        = string
   description = "Cloudflare Account Email"
+  default     = ""
+}
+
+variable "cloudflare_api_key" {
+  type        = string
+  description = "Cloudflare Global API Key"
   default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@ variable "acme_email" {
 
 # Optional variables
 variable "networks" {
-  type        = list
+  type        = list(string)
   description = "List of networks to connect Traefik to."
   default     = ["traefik"]
 }
@@ -61,11 +61,11 @@ variable "lets_encrypt_keytype" {
 }
 
 variable "lets_encrypt_resolvers" {
-  type = list(string)
+  type        = list(string)
   description = "A list of DNS Challange providers to enable in the Traefik configuration"
-  default = []
+  default     = []
   validation {
-    condition    = can([for provider in var.lets_encrypt_resolvers : regex("^cloudflare$", provider)])
+    condition     = can([for provider in var.lets_encrypt_resolvers : regex("^cloudflare$", provider)])
     error_message = "Invalid/Unsupported DNS Provider listed. Supported values are: cloudflare."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,7 @@ variable "traefik_network_attachable" {
 variable "traefik_version" {
   type        = string
   description = "Traefik Docker image version."
-  default     = "2.3.4" # https://github.com/traefik/traefik/releases/latest
+  default     = "2.3.5" # https://github.com/traefik/traefik/releases/latest
 }
 
 variable "password" {

--- a/version.tf
+++ b/version.tf
@@ -1,8 +1,8 @@
 terraform {
-    required_providers {
-        docker = {
-            source = "kreuzwerker/docker"
-        }
+  required_providers {
+    docker = {
+      source = "kreuzwerker/docker"
     }
-    required_version = ">= 0.13, <= 0.14"
+  }
+  required_version = ">= 0.13, <= 0.14"
 }


### PR DESCRIPTION
* Add `locals.tf` file.
* Make Let's Encrypt [`dnsChallenge`](https://doc.traefik.io/traefik/https/acme/#dnschallenge) providers configurable via `list(string)` type variable.
* Separate file for each configurable `dnsChallenge` provider.
* New syntax for predefined "Certificate Resolvers" names in the rendered [static configuration](https://doc.traefik.io/traefik/getting-started/configuration-overview/#the-static-configuration) template (uses camelCase):
    `<providerName>` = Uses the Let's Encrypt production server: `https://acme-v02.api.letsencrypt.org/directory`
    `<providerName>Staging` = Uses the Let's Encrypt staging server: `https://acme-staging-v02.api.letsencrypt.org/directory`.

    e.g. `cloudflare` & `cloudflareStaging`  (see [README](https://github.com/colinwilson/terraform-docker-traefik-v2/blob/master/README.md) for more details).

     `letsEncrypt` & `letsEncryptStaging` ([`httpChallenge`](https://doc.traefik.io/traefik/https/acme/#httpchallenge)) resolvers are configured in the static configuration by default.
* New `traefik_ssl_cert` variable: request a live or staging SSL cert for the Traefik service deployment (default: staging).
