### PR TITLE
♻️ Update variable name; update default Traefik version

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ module "docker-traefik" {
   traefik_network_attachable = true                  # optional
   acme_email                 = "myemail@example.com"
   hostname                   = "traefik.example.com"
-  live_traefik_ssl_cert      = true                  # optional
+  live_cert      = true                  # optional
   lets_encrypt_keytype       = "EC384"               # optional
   lets_encrypt_resolvers     = ["cloudflare"]        # optional
 }
@@ -70,7 +70,7 @@ A Functional example is included in the
 | traefik_network_attachable | Make the default Traefik network attachable. | bool | `false` | no |
 | traefik_version | Which Traefik Docker image version to use. | string | `"2.3.5"` | no |
 | password | Password to login to Traefik dashboard (username: admin). | string | `"traefik"` | no |
-| live_traefik_ssl_cert | Deploy Traefik with a live SSL cert. | bool | `"false"` | no |
+| live_cert | Deploy Traefik with a live SSL cert. | bool | `"false"` | no |
 | lets_encrypt_keytype | SSL cert key type to issue certs with. | string |`"RSA2048"` | no |
 | lets_encrypt_resolvers | List of DNS Challange providers to enable. | list(string) | `[]`| no |
 

--- a/service.tf
+++ b/service.tf
@@ -56,7 +56,7 @@ resource "docker_service" "traefik" {
 
       labels {
         label = "traefik.http.routers.traefik.tls.certresolver"
-        value = var.live_traefik_ssl_cert == false ? "letsEncryptStaging" : "letsEncrypt"
+        value = var.live_cert == false ? "letsEncryptStaging" : "letsEncrypt"
       }
 
       labels {

--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,7 @@ variable "traefik_network_attachable" {
 variable "traefik_version" {
   type        = string
   description = "Traefik Docker image version."
-  default     = "2.3.5" # https://github.com/traefik/traefik/releases/latest
+  default     = "2.3.6" # https://github.com/traefik/traefik/releases/latest
 }
 
 variable "password" {

--- a/variables.tf
+++ b/variables.tf
@@ -40,7 +40,7 @@ variable "password" {
   default     = "traefik"
 }
 
-variable "live_traefik_ssl_cert" {
+variable "live_cert" {
   type        = bool
   description = "Configure the Traefik instance with a live SSL certificate?"
   default     = false # Prevents hitting Let's Encrypts rate limit when testing.


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

* [x] Refactoring (no functional changes)

## What's new?
- update default Traefik version to 2.3.6
- rename `live_traefik_ssl_cert` variable to `live_cert`