### PR TITLE
⚡ update default traefik version to 2.10.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ A Functional example is included in the
 | networks | List of additional networks Traefik should connect to. | list(string) | `[]` | no |
 | traefik_network | Name of Traefik (Docker overlay) network. | string | `"traefik"` | no |
 | traefik_network_attachable | Make the default Traefik network attachable. | bool | `false` | no |
-| traefik_version | Which Traefik Docker image version to use. | string | `"2.9.6"` | no |
+| traefik_version | Which Traefik Docker image version to use. | string | `"2.10.3"` | no |
 | password | Password to login to Traefik dashboard (username: admin). | string | `"traefik"` | no |
 | live_cert | Deploy Traefik with a live SSL cert. | bool | `"false"` | no |
 | lets_encrypt_keytype | SSL cert key type to issue certs with. | string |`"RSA2048"` | no |

--- a/networks.tf
+++ b/networks.tf
@@ -1,5 +1,5 @@
 # Create a new docker network for traefik
-resource "docker_network" "network" {
+resource "docker_network" "traefik" {
   name            = var.traefik_network
   attachable      = var.traefik_network_attachable
   driver          = "overlay"

--- a/output.tf
+++ b/output.tf
@@ -5,7 +5,7 @@ output "acme_volume_mountpoint" {
 
 output "traefik_network_name" {
   description = "Name of the Traefik overlay network"
-  value       = docker_network.network.name
+  value       = docker_network.traefik.name
 }
 
 output "traefik_service_config_name" {

--- a/service.tf
+++ b/service.tf
@@ -120,7 +120,16 @@ resource "docker_service" "traefik" {
         read_only = false
       }
     }
-    networks = concat(values(data.docker_network.additional_networks).*.id, [docker_network.network.id])
+    networks_advanced {
+      name = docker_network.traefik.name
+    }
+
+    dynamic "networks_advanced" {
+      for_each = values(data.docker_network.additional_networks).*.id
+      content {
+        name = each.key
+      }
+    }
   }
 
   endpoint_spec {

--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,7 @@ variable "traefik_network_attachable" {
 variable "traefik_version" {
   type        = string
   description = "Traefik Docker image version."
-  default     = "2.9.6" # https://github.com/traefik/traefik/releases/latest
+  default     = "2.10.3" # https://github.com/traefik/traefik/releases/latest
 }
 
 variable "password" {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

* [x] Refactoring (no functional changes)
* [x] Updates


## What's new?
- Update default Traefik version to `2.10.3`
- Refactor 'additional networks' option
