### PR TITLE
⚡ `service.tf`: reference `docker_network.traefik.id` instead of `doc…

### DIFF
--- a/service.tf
+++ b/service.tf
@@ -121,7 +121,7 @@ resource "docker_service" "traefik" {
       }
     }
     networks_advanced {
-      name = docker_network.traefik.name
+      name = docker_network.traefik.id
     }
 
     dynamic "networks_advanced" {


### PR DESCRIPTION
…ker_network.traefik.name`

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [x] Refactoring (no functional changes)
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other


## What's new?
- In `service.tf`; reference the traefik network by `id` rather than `name`

## Screenshots
N/A